### PR TITLE
Update match pattern for localhost in manifest

### DIFF
--- a/manifest.dev.json
+++ b/manifest.dev.json
@@ -16,7 +16,7 @@
       "js": ["src/ui/toast/toast.js", "src/injection/content.js"]
     },
     {
-      "matches": ["https://*.vercel.app/*", "http://localhost:5173/"],
+      "matches": ["https://*.vercel.app/*", "http://localhost:5173/*"],
       "js": ["src/injection/webapp.js"],
       "run_at": "document_start"
     }


### PR DESCRIPTION
The extension's content script match pattern for localhost was too restrictive. This was causing issues when running in WSL locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to expand script injection matching across all localhost paths, ensuring consistent behavior during local development testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->